### PR TITLE
Remove the omitempty tag 

### DIFF
--- a/component_groups.go
+++ b/component_groups.go
@@ -21,7 +21,7 @@ type ComponentGroup struct {
 	ID                      int         `json:"id,omitempty"`
 	Name                    string      `json:"name,omitempty"`
 	Order                   int         `json:"order,omitempty"`
-	Collapsed               int         `json:"collapsed,omitempty"`
+	Collapsed               int         `json:"collapsed"`
 	Visible                 int         `json:"visible,omitempty"`
 	CreatedAt               string      `json:"created_at,omitempty"`
 	UpdatedAt               string      `json:"updated_at,omitempty"`

--- a/metrics.go
+++ b/metrics.go
@@ -49,7 +49,7 @@ type Metric struct {
 	Places          int    `json:"places,omitempty"`
 	DefaultView     int    `json:"default_view"`
 	Threshold       int    `json:"threshold,omitempty"`
-	Order           int    `json:"order,omitempty"`
+	Order           int    `json:"order"`
 	Visible         int    `json:"visible"`
 	CreatedAt       string `json:"created_at,omitempty"`
 	UpdatedAt       string `json:"updated_at,omitempty"`


### PR DESCRIPTION
The `omitemty` tag on an `int` is unhelpful when marshalling json because if the value is `0`, the field will not be rendered so when making `PUT` requests to the Cachet API, if the value is `0`, the field will not be updated